### PR TITLE
jcgruenhage/formatting

### DIFF
--- a/fos-export
+++ b/fos-export
@@ -5,7 +5,7 @@ sq encrypt -s -f -o "famedly.oca-encrypted" /tmp/famedly.oca
 git commit -a
 
 for partition in $(fos-partitions); do
-  oca -d /tmp/famedly.oca user export > "/mnt/${partition}/exports/export_users_$(date +'%Y-%m-%d').asc"
+    oca -d /tmp/famedly.oca user export >"/mnt/${partition}/exports/export_users_$(date +'%Y-%m-%d').asc"
 done
 
 fos-sync

--- a/fos-mount
+++ b/fos-mount
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 for partition_id in $(fos-partitions); do
-	mkdir "/mnt/${partition_id}"
-	mount "/dev/disk/by-uuid/${partition_id}" "/mnt/${partition_id}" -o uid=1000,gid=1000
+    mkdir "/mnt/${partition_id}"
+    mount "/dev/disk/by-uuid/${partition_id}" "/mnt/${partition_id}" -o uid=1000,gid=1000
 done
 
 fos-sync

--- a/fos-new
+++ b/fos-new
@@ -8,35 +8,35 @@ for var in "name" "email"; do
     fi
 done
 
-read -rp "Enter full name of the employee: " NAME
-read -rp "Enter email localpart of the employee: " LOCALPART
+read -rp "Enter full name of the employee: " name
+read -rp "Enter email localpart of the employee: " localpart
 
-FOS_WORKING_DIR=$(fos-working-directory)
+fos_working_dir=$(fos-working-directory)
 
 # TODO: get proper json interface here, this is terrible
-oca -d /tmp/famedly.oca user add --name "${NAME}" --email "${LOCALPART}@famedly.com" --validity 2y --cipher-suite cv25519 --encryption true --signing true --authentication true 2>&1 | jq -Rs 'capture("(?<key>-----BEGIN PGP PRIVATE KEY BLOCK-----.*-----END PGP PRIVATE KEY BLOCK-----).*Password for this key: .(?<password>[a-z ]*)."; "m")' >/tmp/key.json
+oca -d /tmp/famedly.oca user add --name "${name}" --email "${localpart}@famedly.com" --validity 2y --cipher-suite cv25519 --encryption true --signing true --authentication true 2>&1 | jq -Rs 'capture("(?<key>-----BEGIN PGP PRIVATE KEY BLOCK-----.*-----END PGP PRIVATE KEY BLOCK-----).*Password for this key: .(?<password>[a-z ]*)."; "m")' >/tmp/key.json
 jq -r .password </tmp/key.json >/tmp/old-pass
-mkdir "${FOS_WORKING_DIR}/archive/employee-keys/${LOCALPART}@famedly.com/"
-jq -r .key </tmp/key.json | sq key password --old-password-file /tmp/old-pass --new-password-file /tmp/primary-secret >"${FOS_WORKING_DIR}/archive/employee-keys/${LOCALPART}@famedly.com/secret.asc"
-jq -r .key </tmp/key.json | sq key extract-cert >"${FOS_WORKING_DIR}/archive/employee-keys/${LOCALPART}@famedly.com/public.asc"
+mkdir "${fos_working_dir}/archive/employee-keys/${localpart}@famedly.com/"
+jq -r .key </tmp/key.json | sq key password --old-password-file /tmp/old-pass --new-password-file /tmp/primary-secret >"${fos_working_dir}/archive/employee-keys/${localpart}@famedly.com/secret.asc"
+jq -r .key </tmp/key.json | sq key extract-cert >"${fos_working_dir}/archive/employee-keys/${localpart}@famedly.com/public.asc"
 
-cd "${FOS_WORKING_DIR}/archive"
+cd "${fos_working_dir}/archive"
 
 git add .
-git commit -m "add new employee ${NAME}"
+git commit -m "add new employee ${name}"
 
 echo "123456" >/tmp/user-pin-default
 echo "12345678" >/tmp/admin-pin-default
 
-# TODO: Write encrypted pins into ${FOS_WORKING_DIR}/archive/employee-keys/${LOCALPART}@famedly.com/
+# TODO: Write encrypted pins into ${fos_working_dir}/archive/employee-keys/${localpart}@famedly.com/
 diceware -l reinhold -n 4 | xargs -I{} printf '%s' "{}" >/tmp/user-pin-new
 diceware -l reinhold -n 6 | xargs -I{} printf '%s' "{}" >/tmp/admin-pin-new
 
 while read -rp "Insert the next yubikey, remove any previous ones. 'y' to flash the connected yubikey, 'n' for terminating. (Y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]]; do
-    IDENT="$(oct --output-format json list | jq '.idents.[0]' -r)"
-    oct admin --admin-pin /tmp/admin-pin-default --card "${IDENT}" import --key-passphrase /tmp/primary-secret "${FOS_WORKING_DIR}/archive/employee-keys/${LOCALPART}@famedly.com/secret.asc"
-    oct admin --admin-pin /tmp/admin-pin-default --card "${IDENT}" name "${NAME}"
-    sq network wkd url "${LOCALPART}@famedly.com" | xargs oct admin --admin-pin /tmp/admin-pin-default --card "${IDENT}" url
-    oct pin --card "${IDENT}" set-user --user-pin-old /tmp/user-pin-default --user-pin-new /tmp/user-pin-new
-    oct pin --card "${IDENT}" set-admin --admin-pin-old /tmp/admin-pin-default --admin-pin-new /tmp/admin-pin-new
+    card_identifier="$(oct --output-format json list | jq '.idents.[0]' -r)"
+    oct admin --admin-pin /tmp/admin-pin-default --card "${card_identifier}" import --key-passphrase /tmp/primary-secret "${fos_working_dir}/archive/employee-keys/${localpart}@famedly.com/secret.asc"
+    oct admin --admin-pin /tmp/admin-pin-default --card "${card_identifier}" name "${name}"
+    sq network wkd url "${localpart}@famedly.com" | xargs oct admin --admin-pin /tmp/admin-pin-default --card "${card_identifier}" url
+    oct pin --card "${card_identifier}" set-user --user-pin-old /tmp/user-pin-default --user-pin-new /tmp/user-pin-new
+    oct pin --card "${card_identifier}" set-admin --admin-pin-old /tmp/admin-pin-default --admin-pin-new /tmp/admin-pin-new
 done

--- a/fos-new
+++ b/fos-new
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 for var in "name" "email"; do
-    if ! git config user.${var} > /dev/null; then
+    if ! git config user.${var} >/dev/null; then
         echo "No ${var} set in git config! aborting..."
         exit
     fi
@@ -14,23 +14,23 @@ read -rp "Enter email localpart of the employee: " LOCALPART
 FOS_WORKING_DIR=$(fos-working-directory)
 
 # TODO: get proper json interface here, this is terrible
-oca -d /tmp/famedly.oca user add --name "${NAME}" --email "${LOCALPART}@famedly.com" --validity 2y --cipher-suite cv25519 --encryption true --signing true --authentication true 2>&1 | jq -Rs 'capture("(?<key>-----BEGIN PGP PRIVATE KEY BLOCK-----.*-----END PGP PRIVATE KEY BLOCK-----).*Password for this key: .(?<password>[a-z ]*)."; "m")' > /tmp/key.json
-jq -r .password < /tmp/key.json > /tmp/old-pass
+oca -d /tmp/famedly.oca user add --name "${NAME}" --email "${LOCALPART}@famedly.com" --validity 2y --cipher-suite cv25519 --encryption true --signing true --authentication true 2>&1 | jq -Rs 'capture("(?<key>-----BEGIN PGP PRIVATE KEY BLOCK-----.*-----END PGP PRIVATE KEY BLOCK-----).*Password for this key: .(?<password>[a-z ]*)."; "m")' >/tmp/key.json
+jq -r .password </tmp/key.json >/tmp/old-pass
 mkdir "${FOS_WORKING_DIR}/archive/employee-keys/${LOCALPART}@famedly.com/"
-jq -r .key < /tmp/key.json | sq key password --old-password-file /tmp/old-pass --new-password-file /tmp/primary-secret > "${FOS_WORKING_DIR}/archive/employee-keys/${LOCALPART}@famedly.com/secret.asc"
-jq -r .key < /tmp/key.json | sq key extract-cert > "${FOS_WORKING_DIR}/archive/employee-keys/${LOCALPART}@famedly.com/public.asc"
+jq -r .key </tmp/key.json | sq key password --old-password-file /tmp/old-pass --new-password-file /tmp/primary-secret >"${FOS_WORKING_DIR}/archive/employee-keys/${LOCALPART}@famedly.com/secret.asc"
+jq -r .key </tmp/key.json | sq key extract-cert >"${FOS_WORKING_DIR}/archive/employee-keys/${LOCALPART}@famedly.com/public.asc"
 
 cd "${FOS_WORKING_DIR}/archive"
 
 git add .
 git commit -m "add new employee ${NAME}"
 
-echo "123456" > /tmp/user-pin-default
-echo "12345678" > /tmp/admin-pin-default
+echo "123456" >/tmp/user-pin-default
+echo "12345678" >/tmp/admin-pin-default
 
 # TODO: Write encrypted pins into ${FOS_WORKING_DIR}/archive/employee-keys/${LOCALPART}@famedly.com/
-diceware -l reinhold -n 4 | xargs -I{} printf '%s' "{}" > /tmp/user-pin-new
-diceware -l reinhold -n 6 | xargs -I{} printf '%s' "{}" > /tmp/admin-pin-new
+diceware -l reinhold -n 4 | xargs -I{} printf '%s' "{}" >/tmp/user-pin-new
+diceware -l reinhold -n 6 | xargs -I{} printf '%s' "{}" >/tmp/admin-pin-new
 
 while read -rp "Insert the next yubikey, remove any previous ones. 'y' to flash the connected yubikey, 'n' for terminating. (Y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]]; do
     IDENT="$(oct --output-format json list | jq '.idents.[0]' -r)"

--- a/fos-partitions
+++ b/fos-partitions
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+partitions_found=0
+
 for part in "B9C8-D9A6" "EC3D-3102" "F055-B17B"; do
-    ls /dev/disk/by-uuid/${part} 2>/dev/null >/dev/null && echo "${part}"
+    if [[ -L "/dev/disk/by-uuid/${part}" ]]; then
+        echo "${part}"
+        partitions_found=$((partitions_found+1))
+    fi
 done
+
+if [[ "$partitions_found" ==  "0" ]]; then
+    echo "No stick found!" >&2
+    exit 1
+fi

--- a/fos-partitions
+++ b/fos-partitions
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 for part in "B9C8-D9A6" "EC3D-3102" "F055-B17B"; do
-  ls /dev/disk/by-uuid/${part} 2> /dev/null > /dev/null && echo "${part}"
+    ls /dev/disk/by-uuid/${part} 2>/dev/null >/dev/null && echo "${part}"
 done

--- a/fos-sync
+++ b/fos-sync
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 for partition in $(fos-partitions); do
-  cd "/mnt/${partition}/archive"
-  for other in $(fos-partitions); do
-    if [ "$partition" != "$other" ]; then
-      if ! git remote | grep -q "^${other}$"; then
-         git remote add "$other" "/mnt/${other}/archive"
-      fi
-      git fetch "${other}"
-      git merge --ff-only "${other}/main"
-    fi
-  done
+    cd "/mnt/${partition}/archive"
+    for other in $(fos-partitions); do
+        if [ "$partition" != "$other" ]; then
+            if ! git remote | grep -q "^${other}$"; then
+                git remote add "$other" "/mnt/${other}/archive"
+            fi
+            git fetch "${other}"
+            git merge --ff-only "${other}/main"
+        fi
+    done
 done

--- a/fos-working-directory
+++ b/fos-working-directory
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 for partition_id in $(fos-partitions); do
-	if [[ -h "/dev/disk/by-uuid/${partition_id}" ]]; then
-		echo "/mnt/${partition_id}"
-		exit 0
-	fi
+    if [[ -L "/dev/disk/by-uuid/${partition_id}" ]]; then
+        echo "/mnt/${partition_id}"
+        exit 0
+    fi
 done
 echo "No stick found!" >&2
 exit 1

--- a/fos-working-directory
+++ b/fos-working-directory
@@ -1,10 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-for partition_id in $(fos-partitions); do
-    if [[ -L "/dev/disk/by-uuid/${partition_id}" ]]; then
-        echo "/mnt/${partition_id}"
-        exit 0
-    fi
-done
-echo "No stick found!" >&2
-exit 1
+partition="$(fos-partitions | head -n 1)"
+echo "/mnt/${partition}"


### PR DESCRIPTION
- **chore: reformat using `shfmt`**
- **chore(fos-new): consistently use snake_case variable names**
- **chore: remove duplicate stick check from fos-partitions and fos-working-directory**

Fixes https://github.com/famedly/openpgp-scripts/issues/11
